### PR TITLE
Replacing cassandra-cli scripts with CQL

### DIFF
--- a/src/it/smoke/src/cassandra/cli/load.script
+++ b/src/it/smoke/src/cassandra/cli/load.script
@@ -1,7 +1,0 @@
-create keyspace TestKeyspace
-    with placement_strategy = 'org.apache.cassandra.locator.SimpleStrategy'
-    and strategy_options = {replication_factor:1};
-
-use TestKeyspace;
-create column family Test with column_type='Standard' and comparator='UTF8Type';
-describe TestKeyspace;

--- a/src/it/smoke/src/cassandra/cql/load.cql
+++ b/src/it/smoke/src/cassandra/cql/load.cql
@@ -1,0 +1,6 @@
+create keyspace TestKeyspace
+    with strategy_class = 'SimpleStrategy'
+    and strategy_options:replication_factor = 1;
+
+use TestKeyspace;
+create columnfamily Test (key uuid PRIMARY KEY) with comparator='UTF8Type';

--- a/src/it/spaces in path/src/cassandra/cli/load.script
+++ b/src/it/spaces in path/src/cassandra/cli/load.script
@@ -1,7 +1,0 @@
-create keyspace TestKeyspaceWithSpace
-    with placement_strategy = 'org.apache.cassandra.locator.SimpleStrategy'
-    and strategy_options = {replication_factor:1};
-
-use TestKeyspaceWithSpace;
-create column family Test with column_type='Standard' and comparator='UTF8Type';
-describe TestKeyspaceWithSpace;

--- a/src/it/spaces in path/src/cassandra/cql/load.cql
+++ b/src/it/spaces in path/src/cassandra/cql/load.cql
@@ -1,0 +1,6 @@
+create keyspace TestKeyspaceWithSpace
+    with strategy_class = 'SimpleStrategy'
+    and strategy_options:replication_factor = 1;
+
+use TestKeyspaceWithSpace;
+create columnfamily Test (key uuid PRIMARY KEY) with comparator='UTF8Type';

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -18,12 +18,8 @@
  */
 package org.codehaus.mojo.cassandra;
 
-import org.apache.cassandra.cli.CliMain;
-//import org.apache.cassandra.tools.NodeCmd;
-
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.OS;
-
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.ArtifactUtils;
 import org.apache.maven.execution.MavenSession;
@@ -411,12 +407,6 @@ public abstract class AbstractCassandraMojo
             getLog().debug( ( cassandraJar.isFile() ? "Updating " : "Creating " ) + cassandraJar );
             createCassandraJar( cassandraJar, CassandraMonitor.class.getName(), cassandraDir );
         }
-        File cassandraCliJar = new File( bin, "cassandra-cli.jar" );
-        if ( Utils.shouldGenerateResource( project, cassandraCliJar ) )
-        {
-            getLog().debug( ( cassandraCliJar.isFile() ? "Updating " : "Creating " ) + cassandraCliJar );
-            createCassandraJar( cassandraCliJar, CliMain.class.getName(), cassandraDir );
-        }
         /*
         File nodetoolJar = new File( bin, "nodetool.jar" );
         if ( Utils.shouldGenerateResource( project, nodetoolJar ) )
@@ -654,36 +644,10 @@ public abstract class AbstractCassandraMojo
     }
 
     /**
-     * Creates the command line to launch the {@code cassandra-cli} utility.
+     * Creates the command line to launch the {@code nodetool} utility.
      *
-     * @param args the command line arguments to pass to the {@code cassandra-cli} utility.
-     * @return the {@link CommandLine} to launch {@code cassandra-cli} with the supplied arguments.
-     * @throws IOException if there are issues creating the cassandra home directory.
-     */
-    protected CommandLine newCliCommandLine( String... args )
-        throws IOException
-    {
-        createCassandraHome();
-        CommandLine commandLine = newJavaCommandLine();
-        commandLine.addArgument( "-jar" );
-        // It seems that java cannot handle quoted jar file names...
-        commandLine.addArgument( new File( new File( cassandraDir, "bin" ), "cassandra-cli.jar" ).getAbsolutePath(),
-                                 false );
-        commandLine.addArgument( "--host" );
-        commandLine.addArgument( rpcAddress );
-        commandLine.addArgument( "--port" );
-        commandLine.addArgument( Integer.toString( rpcPort ) );
-        commandLine.addArgument( "--jmxport" );
-        commandLine.addArgument( Integer.toString( jmxPort ) );
-        commandLine.addArguments( args );
-        return commandLine;
-    }
-
-    /**
-     * Creates the command line to launch the {@code cassandra-cli} utility.
-     *
-     * @param args the command line arguments to pass to the {@code cassandra-cli} utility.
-     * @return the {@link CommandLine} to launch {@code cassandra-cli} with the supplied arguments.
+     * @param args the command line arguments to pass to the {@code nodetool} utility.
+     * @return the {@link CommandLine} to launch {@code nodetool} with the supplied arguments.
      * @throws IOException if there are issues creating the cassandra home directory.
      */
     protected CommandLine newNodetoolCommandLine( String... args )

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -1,0 +1,130 @@
+package org.codehaus.mojo.cassandra;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.cassandra.thrift.Cassandra.Client;
+import org.apache.cassandra.thrift.Compression;
+import org.apache.cassandra.thrift.ConsistencyLevel;
+import org.apache.cassandra.thrift.CqlResult;
+import org.apache.cassandra.utils.ByteBufferUtil;
+import org.apache.commons.lang.StringUtils;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.IOUtil;
+
+/**
+ * Abstract parent class for mojos that need to run CQL statements.
+ *
+ * @author sparhomenko
+ */
+public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
+{
+    /**
+     * Version of CQL to use
+     *
+     * @parameter expression="${cql.version}"
+     * @since 1.2.1-2
+     */
+    private String cqlVersion = "2.0.0";
+
+    protected String readFile(File file) throws MojoExecutionException
+    {
+        if (!file.isFile())
+        {
+            throw new MojoExecutionException("script " + file + " does not exist.");
+        }
+
+        FileReader fr = null;
+        try
+        {
+            fr = new FileReader(file);
+            return IOUtil.toString(fr);
+        } catch (FileNotFoundException e)
+        {
+            throw new MojoExecutionException("Cql file '" + file + "' was deleted before I could read it", e);
+        } catch (IOException e)
+        {
+            throw new MojoExecutionException("Could not parse or load cql file", e);
+        } finally
+        {
+            IOUtil.close(fr);
+        }
+    }
+
+    protected List<CqlResult> executeCql(final String statements) throws MojoExecutionException
+    {
+        final List<CqlResult> results = new ArrayList<CqlResult>();
+        if (StringUtils.isBlank(statements))
+        {
+            getLog().warn("No CQL provided. Nothing to do.");
+        } else
+        {
+            try
+            {
+                CqlExecOperation operation = new CqlExecOperation(statements);
+                Utils.executeThrift(operation);
+                results.addAll(operation.results);
+            } catch (ThriftApiExecutionException taee)
+            {
+                throw new MojoExecutionException(taee.getMessage(), taee);
+            }
+        }
+        return results;
+    }
+
+    private class CqlExecOperation extends ThriftApiOperation
+    {
+        private final List<CqlResult> results = new ArrayList<CqlResult>();
+        private final String[] statements;
+
+        private CqlExecOperation(String statements)
+        {
+            super(rpcAddress, rpcPort);
+            this.statements = statements.split(";");
+            if (StringUtils.isNotBlank(keyspace))
+            {
+                getLog().info("setting keyspace: " + keyspace);
+                setKeyspace(keyspace);
+            }
+            getLog().info("setting cqlversion: " + cqlVersion);
+            setCqlVersion(cqlVersion);
+        }
+
+        @Override
+        void executeOperation(Client client) throws ThriftApiExecutionException
+        {
+            for (String statement : statements)
+            {
+                if (StringUtils.isNotBlank(statement))
+                {
+                    results.add(executeStatement(client, statement));
+                }
+            }
+        }
+
+        private CqlResult executeStatement(Client client, String statement) throws ThriftApiExecutionException
+        {
+            ByteBuffer buf = ByteBufferUtil.bytes(statement);
+            try
+            {
+                if (cqlVersion.charAt(0) >= '3')
+                {
+                    return client.execute_cql3_query(buf, Compression.NONE, ConsistencyLevel.ONE);
+                } else
+                {
+                    return client.execute_cql_query(buf, Compression.NONE);
+                }
+            } catch (Exception e)
+            {
+                getLog().debug(statement);
+                throw new ThriftApiExecutionException(e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlLoadMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlLoadMojo.java
@@ -1,0 +1,49 @@
+package org.codehaus.mojo.cassandra;
+
+import java.io.File;
+
+import org.apache.maven.plugin.MojoExecutionException;
+
+/**
+ * Abstract parent class for mojos that load and execute CQL statements from a file.
+ *
+ * @author sparhomenko
+ */
+public abstract class AbstractCqlLoadMojo extends AbstractCqlExecMojo
+{
+    /**
+     * The CQL file to load.
+     *
+     * @parameter default-value="${basedir}/src/cassandra/cql/load.cql"
+     */
+    private File script;
+
+    /**
+     * Whether to ignore errors when loading the script.
+     *
+     * @parameter expression="${cassandra.load.failure.ignore}"
+     */
+    private boolean loadFailureIgnore;
+
+    protected void execCqlFile() throws MojoExecutionException
+    {
+        if (script != null)
+        {
+            getLog().info("Running " + script + "...");
+            try
+            {
+                executeCql(readFile(script));
+                getLog().info("Finished " + script + ".");
+            } catch (MojoExecutionException e)
+            {
+                if (loadFailureIgnore)
+                {
+                    getLog().error("Script execution failed with " + e.getMessage() + ". Ignoring.");
+                } else
+                {
+                    throw e;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
@@ -1,33 +1,17 @@
 package org.codehaus.mojo.cassandra;
 
-import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
-import org.apache.cassandra.config.DatabaseDescriptor;
 import org.apache.cassandra.db.marshal.AbstractType;
 import org.apache.cassandra.db.marshal.TypeParser;
 import org.apache.cassandra.exceptions.ConfigurationException;
 import org.apache.cassandra.exceptions.SyntaxException;
 import org.apache.cassandra.thrift.Column;
-import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.CqlResult;
 import org.apache.cassandra.thrift.CqlRow;
-import org.apache.cassandra.thrift.Cassandra.Client;
-import org.apache.cassandra.thrift.ConsistencyLevel;
-import org.apache.cassandra.utils.ByteBufferUtil;
-import org.apache.commons.lang.StringUtils;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.codehaus.plexus.util.FileUtils;
-import org.codehaus.plexus.util.IOUtil;
 
 /**
  * Executes cql statements from maven.
@@ -37,7 +21,7 @@ import org.codehaus.plexus.util.IOUtil;
  * @threadSafe
  * @phase pre-integration-test
  */
-public class CqlExecCassandraMojo extends AbstractCassandraMojo {
+public class CqlExecCassandraMojo extends AbstractCqlExecMojo {
 
   /**
    * The CQL script which will be executed
@@ -71,13 +55,6 @@ public class CqlExecCassandraMojo extends AbstractCassandraMojo {
    */
   protected String comparator = "BytesType";
 
-  /**
-   * Version of CQL to use
-   * @parameter expression="${cql.version}"
-   * @since 1.2.1-2
-   */
-  protected String cqlVersion = "2.0.0";
-
   private AbstractType<?> comparatorVal;
   private AbstractType<?> keyValidatorVal;
   private AbstractType<?> defaultValidatorVal;
@@ -102,66 +79,28 @@ public class CqlExecCassandraMojo extends AbstractCassandraMojo {
       {
         throw new MojoExecutionException("Could not parse comparator value: " + comparator, e);
       }
-      List<CqlExecOperation> cqlOps = new ArrayList<CqlExecOperation>();
       if (cqlScript != null && cqlScript.isFile())
       {
-          FileReader fr = null;
-          try
-          {
-              fr = new FileReader(cqlScript);
-              cqlStatement = IOUtil.toString(fr);
-          } catch (FileNotFoundException e)
-          {
-              throw new MojoExecutionException("Cql file '" + cqlScript + "' was deleted before I could read it", e);
-          } catch (IOException e)
-          {
-              throw new MojoExecutionException("Could not parse or load cql file", e);
-          } finally
-          {
-              IOUtil.close(fr);
-          }
+          cqlStatement = readFile(cqlScript);
       }
 
-      if (StringUtils.isBlank(cqlStatement))
-      {
-          getLog().warn("No CQL provided. Nothing to do.");
-      } else
-      {
-          // TODO accept keyFormat, columnFormat, valueFormat
-          // ^ are these relevant on file load?
-          if (cqlStatement.contains(";"))
-          {
-              for (String op : StringUtils.split(cqlStatement, ";"))
-              {
-                  if ( StringUtils.isNotBlank(op) ) {
-                      cqlOps.add(doExec(op));
-                  }
-              }
-          } else
-          {
-              if ( StringUtils.isNotBlank(cqlStatement) ) {
-                  cqlOps.add(doExec(cqlStatement));
-              }
-          }
-          printResults(cqlOps);
-      }
+      printResults(executeCql(cqlStatement));
   }
 
   /*
    * Encapsulate print of CqlResult. Uses specified configuration options to format results
    */
-  private void printResults(List<CqlExecOperation> cqlOps)
+  private void printResults(List<CqlResult> results)
   {
       // TODO fix ghetto formatting
       getLog().info("-----------------------------------------------");
-      for (CqlExecOperation cqlExecOperation : cqlOps)
+      for (CqlResult result : results)
       {
-          while ( cqlExecOperation.hasNext() )
+          for (CqlRow row : result.getRows())
           {
-              CqlRow cqlRow = cqlExecOperation.next();
-              getLog().info("Row key: "+keyValidatorVal.getString(cqlRow.key));
+              getLog().info("Row key: "+keyValidatorVal.getString(row.key));
               getLog().info("-----------------------------------------------");
-              for (Column column : cqlRow.getColumns() )
+              for (Column column : row.getColumns() )
               {
                   getLog().info(" name: "+comparatorVal.getString(column.name));
                   getLog().info(" value: "+defaultValidatorVal.getString(column.value));
@@ -170,99 +109,6 @@ public class CqlExecCassandraMojo extends AbstractCassandraMojo {
 
           }
       }
-  }
-
-  /*
-   * Encapsulate op execution for file vs. statement
-   */
-  private CqlExecOperation doExec(String cqlStatement) throws MojoExecutionException
-  {
-      CqlExecOperation cqlOp = new CqlExecOperation(rpcAddress, rpcPort, cqlStatement);
-      if ( StringUtils.isNotBlank(keyspace))
-      {
-          getLog().info("setting keyspace: " + keyspace);
-          cqlOp.setKeyspace(keyspace);
-      }
-      getLog().info("setting cqlversion: " + cqlVersion);
-      cqlOp.setCqlVersion( cqlVersion );
-      try
-      {
-          Utils.executeThrift(cqlOp);
-      } catch (ThriftApiExecutionException taee)
-      {
-          throw new MojoExecutionException(taee.getMessage(), taee);
-      }
-      return cqlOp;
-  }
-
-  class CqlExecOperation extends ThriftApiOperation implements Iterator<CqlRow> {
-
-      CqlResult result;
-      final ByteBuffer statementBuf;
-      CqlRow current;
-      Iterator<CqlRow> rowIter;
-
-      public CqlExecOperation(String rpcAddress, int rpcPort, String cqlStatement)
-      {
-          super(rpcAddress, rpcPort);
-          this.statementBuf = ByteBufferUtil.bytes(cqlStatement);
-      }
-
-      @Override
-      void executeOperation(Client client) throws ThriftApiExecutionException
-      {
-          try
-          {
-              if ("3.0.0".equals(getCqlVersion()))
-              {
-                result = client.execute_cql3_query(statementBuf, Compression.NONE, ConsistencyLevel.ONE );
-              }
-              else
-              {
-                result = client.execute_cql_query(statementBuf, Compression.NONE);
-              }
-              rowIter = result.getRowsIterator();
-          } catch (Exception e)
-          {
-              try {
-                  getLog().debug(ByteBufferUtil.string(statementBuf));
-              } catch(CharacterCodingException cce) {
-                  getLog().debug(cce);
-              }
-              throw new ThriftApiExecutionException(e);
-          }
-      }
-
-      @Override
-      public boolean hasNext()
-      {
-          return rowIter != null && rowIter.hasNext();
-      }
-
-      @Override
-      public CqlRow next()
-      {
-
-          current = rowIter.next();
-          return current;
-      }
-
-      @Override
-      public void remove()
-      {
-          rowIter.remove();
-      }
-
-      List<Column> getColumns()
-      {
-          return current.getColumns();
-      }
-
-      ByteBuffer getKey()
-      {
-          return current.bufferForKey();
-      }
-
   }
 
 }

--- a/src/main/java/org/codehaus/mojo/cassandra/LoadCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/LoadCassandraMojo.java
@@ -18,37 +18,19 @@
  */
 package org.codehaus.mojo.cassandra;
 
-import org.apache.commons.exec.ExecuteException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 
-import java.io.File;
-import java.io.IOException;
-
 /**
- * Loads a {@code cassandra-cli} bscript into a Cassandra instance.
+ * Loads a Cassandra CQL script into a Cassandra instance.
  *
  * @author stephenc
  * @goal load
  * @threadSafe
  * @phase pre-integration-test
  */
-public class LoadCassandraMojo extends AbstractCassandraMojo
+public class LoadCassandraMojo extends AbstractCqlLoadMojo
 {
-    /**
-     * The script to load.
-     *
-     * @parameter default-value="${basedir}/src/cassandra/cli/load.script"
-     */
-    protected File script;
-
-    /**
-     * Whether to ignore errors when loading the script.
-     *
-     * @parameter expression="${cassandra.load.failure.ignore}"
-     */
-    private boolean loadFailureIgnore;
-
     /**
      * {@inheritDoc}
      */
@@ -59,39 +41,7 @@ public class LoadCassandraMojo extends AbstractCassandraMojo
             getLog().info("Skipping cassandra: cassandra.skip==true");
             return;
         }
-        try
-        {
-            if (!script.isFile())
-            {
-                if (loadFailureIgnore)
-                {
-                    getLog().error("Specified script " + script + " does not exist."
-                            + ". Ignoring as loadFailureIgnore is true");
-                    return;
-                }
-                else
-                {
-                    throw new MojoFailureException("Specified script " + script + " does not exist.");
-                }
-            }
 
-            int rv = Utils.runLoadScript(cassandraDir, newCliCommandLine("--file", script.getAbsolutePath()),
-                    createEnvironmentVars(), getLog());
-            if (rv != 0)
-            {
-                if (loadFailureIgnore)
-                {
-                    getLog().error("Command exited with error code " + rv + ". Ignoring as loadFailureIgnore is true");
-                }
-                else
-                {
-                    throw new MojoExecutionException("Command exited with error code " + rv);
-                }
-            }
-        } catch (IOException e)
-        {
-            throw new MojoExecutionException(e.getLocalizedMessage(), e);
-        }
+        execCqlFile();
     }
-
 }

--- a/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
@@ -38,7 +38,7 @@ import java.util.Arrays;
  * @phase pre-integration-test
  */
 public class StartCassandraClusterMojo
-    extends AbstractCassandraMojo
+    extends AbstractCqlLoadMojo
 {
     /**
      * How long to wait for Cassandra to be started before finishing the goal. A value of 0 will wait indefinately. A
@@ -47,20 +47,6 @@ public class StartCassandraClusterMojo
      * @parameter default-value="180"
      */
     protected int startWaitSeconds;
-
-    /**
-     * The script to load.
-     *
-     * @parameter default-value="${basedir}/src/cassandra/cli/load.script"
-     */
-    protected File script;
-
-    /**
-     * Whether to ignore errors when loading the script.
-     *
-     * @parameter expression="${cassandra.load.failure.ignore}"
-     */
-    private boolean loadFailureIgnore;
 
     /**
      * When {@code true}, if this is a clean start then the load script will be applied automatically.
@@ -170,27 +156,9 @@ public class StartCassandraClusterMojo
                     }
                 }
             }
-            if ( isClean && loadAfterFirstStart && script != null && script.isFile() )
+            if ( isClean && loadAfterFirstStart)
             {
-                getLog().info( "Running " + script + "..." );
-                int rv = Utils.runLoadScript( cassandraDir[0], newCliCommandLine( "--file", script.getAbsolutePath() ),
-                                              createEnvironmentVars(), getLog() );
-                if ( rv != 0 )
-                {
-                    if ( loadFailureIgnore )
-                    {
-                        getLog().error(
-                            "Command exited with error code " + rv + ". Ignoring as loadFailureIgnore is true" );
-                    }
-                    else
-                    {
-                        throw new MojoExecutionException( "Command exited with error code " + rv );
-                    }
-                }
-                else
-                {
-                    getLog().info( "Finished " + script + "." );
-                }
+                execCqlFile();
             }
 
             if ( isClean && cuLoadAfterFirstStart && cuDataSet != null && cuDataSet.isFile() )

--- a/src/main/java/org/codehaus/mojo/cassandra/Utils.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/Utils.java
@@ -287,40 +287,6 @@ public final class Utils
     }
 
     /**
-     * Runs the cassandra-cli load script command.
-     * @param cassandraDir The directory to start the cassandra-cli process in.
-     * @param commandLine  The command line to use to start the cassandra-cli process.
-     * @param environment  The environment to start the cassandra-cli process with.
-     * @param log          The log to send the output to.
-     * @return The exit code of the cassandra-cli process.
-     * @throws MojoExecutionException if something went wrong.
-     */
-    public static int runLoadScript(File cassandraDir, CommandLine commandLine, Map environment, Log log) throws MojoExecutionException {
-        Executor exec = new DefaultExecutor();
-        exec.setWorkingDirectory(cassandraDir);
-        exec.setProcessDestroyer(new ShutdownHookProcessDestroyer());
-
-        LogOutputStream stdout = new MavenLogOutputStream(log);
-        LogOutputStream stderr = new MavenLogOutputStream(log);
-
-        try
-        {
-            log.debug("Executing command line: " + commandLine);
-
-            exec.setStreamHandler(new PumpStreamHandler(stdout, stderr));
-
-            exec.execute(commandLine, environment);
-            return 0;
-        } catch (ExecuteException e)
-        {
-            return e.getExitValue();
-        } catch (IOException e)
-        {
-            throw new MojoExecutionException("Command execution failed.", e);
-        }
-    }
-    
-    /**
      * Call {@link #executeOperation(Cassandra.Client)} on the provided operation
      * @throws MojoExecutionException
      * @throws MojoFailureException
@@ -340,11 +306,8 @@ public final class Utils
             {
                 cassandraClient.set_keyspace(thriftApiOperation.getKeyspace());
             }
-            if ( "3.0.0".equals(thriftApiOperation.getCqlVersion())) 
-            {
-                cassandraClient.set_cql_version("3.0.0");
-            }
-            thriftApiOperation.executeOperation(cassandraClient);            
+            cassandraClient.set_cql_version(thriftApiOperation.getCqlVersion());
+            thriftApiOperation.executeOperation(cassandraClient);
         } catch (ThriftApiExecutionException taee) 
         {
             throw new MojoExecutionException("API Exception calling Apache Cassandra", taee);

--- a/src/site/apt/examples/developing-webapp.apt.vm
+++ b/src/site/apt/examples/developing-webapp.apt.vm
@@ -63,8 +63,8 @@ Developing a web application
 mvn cassandra:start jetty:run
 ---
 
-  If the web application is expecting keyspaces to be defined, we can use a <<<cassandra-cli>>> script to create the
-  keyspaces for us. We create a file called <<<src/cassandra/cli/load.script>>>. By default <<<cassandra:start>>>
+  If the web application is expecting keyspaces to be defined, we can use a CQL script to create the
+  keyspaces for us. We create a file called <<<src/cassandra/cql/load.cql>>>. By default <<<cassandra:start>>>
   will run this script if the cassandra instance has not been created yet. If the automatic detection does not
   work for you, you can invoke <<<cassandra:load>>> manually.
 

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -42,7 +42,7 @@ Mojo's Cassandra Maven Plugin
 
   * {{{./run-mojo.html}cassandra:run}} Starts up a test instance of Cassandra in the foreground.
 
-  * {{{./load-mojo.html}cassandra:load}} Runs a <<<cassandra-cli>>> script against the test instance of Cassandra.
+  * {{{./load-mojo.html}cassandra:load}} Runs a CQL script against the test instance of Cassandra.
   
   * {{{./cu-load-mojo.html}cassandra:cu-load}} Load a CassandraUnit dataSet against the test instance of Cassandra.
 


### PR DESCRIPTION
The current version of `cassandra-maven-plugin` is relying on `cassandra-cli` shell to run the load scripts in various mojos. This shell does not allow to use CQL scripts to initialise Cassandra nodes. It is also deprecated Cassandra 2.1 that the plugin currently uses and is scheduled for removal.

Some CQL support is already available in the `cql-exec` mojo. This PR expands that to also be used in script loading mojos (`load`, `run`, `start` and `start-cluster`), replacing all usages of `cassandra-cli`. An alternative could be to start using `cqlsh`, but `cql-exec` way of using the API seems nicer and does not require running a forked `java` process (can be improved further though by switching to native transport as Thrift API is now legacy). It is not backward compatible and would require converting existing `load.script` files to CQL, but it seems reasonable to expect that most Cassandra 2.1+ users would be using CQL instead of `cassandra-cli` scripts.

I'm new to the project, and I tried to mimic the design and formatting to match existing codebase. Please feel free to suggest any changes you see necessary to accept this.