### PR TITLE
Configure log level of cassandra process

### DIFF
--- a/src/it/smoke/pom.xml
+++ b/src/it/smoke/pom.xml
@@ -57,6 +57,18 @@ under the License.
       <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>@log4jVersion@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4jVersion@</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/it/smoke/src/test/resources/log4j2.xml
+++ b/src/it/smoke/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/it/spaces in path/pom.xml
+++ b/src/it/spaces in path/pom.xml
@@ -57,6 +57,18 @@ under the License.
       <version>4.8.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>@log4jVersion@</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>@log4jVersion@</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -133,6 +145,18 @@ under the License.
             </goals>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>@log4jVersion@</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>@log4jVersion@</version>
+          </dependency>
+        </dependencies>
         <configuration>
           <loadAfterFirstStart>false</loadAfterFirstStart>
           <rpcPort>${cassandraPort}</rpcPort>

--- a/src/it/spaces in path/src/test/resources/log4j2.xml
+++ b/src/it/spaces in path/src/test/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -241,6 +241,14 @@ public abstract class AbstractCassandraMojo
     protected Map<String, String> systemPropertyVariables;
 
     /**
+     * Log level of cassandra process. Logging is performed via log4j2.
+     *
+     * @parameter default-value="ERROR"
+     * @since 3.5
+     */
+    protected String logLevel;
+
+    /**
      * Create a jar with just a manifest containing a Main-Class entry for SurefireBooter and a Class-Path entry for
      * all classpath elements. Copied from surefire (ForkConfiguration#createJar())
      *
@@ -389,17 +397,17 @@ public abstract class AbstractCassandraMojo
             createCassandraYaml( cassandraYaml, data, commitlog, savedCaches, listenAddress, rpcAddress, initialToken,
                                  seeds );
         }
-        File log4jServerProperties = new File( conf, "log4j-server.properties" );
-        if ( Utils.shouldGenerateResource( project, log4jServerProperties ) )
+        File log4jServerConfig = new File( conf, "log4j-server.xml" );
+        if ( Utils.shouldGenerateResource( project, log4jServerConfig ) )
         {
-            getLog().debug( ( log4jServerProperties.isFile() ? "Updating " : "Creating " ) + log4jServerProperties );
-            FileUtils.copyURLToFile( getClass().getResource( "/log4j.properties" ), log4jServerProperties );
+            getLog().debug( ( log4jServerConfig.isFile() ? "Updating " : "Creating " ) + log4jServerConfig );
+            FileUtils.copyURLToFile( getClass().getResource("/log4j2.xml"), log4jServerConfig );
         }
-        File log4jClientProperties = new File( conf, "log4j-client.properties" );
-        if ( Utils.shouldGenerateResource( project, log4jClientProperties ) )
+        File log4jClientConfig = new File( conf, "log4j-client.xml" );
+        if ( Utils.shouldGenerateResource( project, log4jClientConfig ) )
         {
-            getLog().debug( ( log4jClientProperties.isFile() ? "Updating " : "Creating " ) + log4jClientProperties );
-            FileUtils.copyURLToFile( getClass().getResource( "/log4j.properties" ), log4jClientProperties );
+            getLog().debug( ( log4jClientConfig.isFile() ? "Updating " : "Creating " ) + log4jClientConfig );
+            FileUtils.copyURLToFile( getClass().getResource("/log4j2.xml"), log4jClientConfig );
         }
         File cassandraJar = new File( bin, "cassandra.jar" );
         if ( Utils.shouldGenerateResource( project, cassandraJar ) )
@@ -617,9 +625,10 @@ public abstract class AbstractCassandraMojo
             commandLine.addArgument( "-D" + CassandraMonitor.PORT_PROPERTY_NAME + "=" + stopPort );
             commandLine.addArgument( "-D" + CassandraMonitor.HOST_PROPERTY_NAME + "=" + listenAddress );
         }
-        commandLine.addArgument( "-Dlog4j.configuration=" + new File( new File( cassandraDir, "conf" ),
-                                                                      "log4j-server.properties" ).toURI().toURL().toString() );
+        commandLine.addArgument( "-Dlog4j.configurationFile=" + new File( new File( cassandraDir, "conf" ),
+                                                                      "log4j-server.xml" ).toURI().toURL().toString() );
         commandLine.addArgument( "-Dcom.sun.management.jmxremote=" + jmxRemoteEnabled );
+        commandLine.addArgument( "-DcassandraLogLevel=" + logLevel );
         if ( jmxRemoteEnabled )
         {
             commandLine.addArgument( "-Dcom.sun.management.jmxremote.port=" + jmxPort );

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+    <Appenders>
+        <Console name="STDOUT" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d %-5p [%t] %C{2} (%F:%L) - %m%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="${sys:cassandraLogLevel}">
+            <AppenderRef ref="STDOUT"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Ability to set log level for cassandra process via <logLevel> param. Defaults to ERROR.

Also fixed minor logging problems - see commit messages for details.

It should be noted in plugin documentation that for logs to work slf4j/log4j dependencies should be added to pom.xml of project that uses the plugin. I'm not sure if this is correct way to do this, perhaps dependencies should be added to plugin in compile scope instead of test, but this may create compilcation at launch time if another logging system is used.

Usage example:

```xml
<plugin>
    <groupId>org.codehaus.mojo</groupId>
    <artifactId>cassandra-maven-plugin</artifactId>
    <version>3.5-SNAPSHOT</version>
    <dependencies>
        <dependency>
            <groupId>net.java.dev.jna</groupId>
            <artifactId>jna</artifactId>
            <version>4.0.0</version>
        </dependency>
        <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-slf4j-impl</artifactId>
            <version>2.1</version>
        </dependency>
        <dependency>
            <groupId>org.apache.logging.log4j</groupId>
            <artifactId>log4j-core</artifactId>
            <version>2.1</version>
        </dependency>
    </dependencies>
    <configuration>
        <startNativeTransport>true</startNativeTransport>
        <logLevel>debug</logLevel>
    </configuration>
    <executions>
        <execution>
            <goals>
                <goal>start</goal>
            </goals>
            <phase>pre-integration-test</phase>
        </execution>
    </executions>
</plugin>
```