### PR TITLE
Switch to Cassandra 3.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@ under the License.
   </parent>
 
   <artifactId>cassandra-maven-plugin</artifactId>
-  <version>2.1.7-2-SNAPSHOT</version>
+  <version>3.5-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Mojo's Cassandra Maven Plugin</name>
@@ -97,7 +97,7 @@ under the License.
 
   <properties>
     <mavenVersion>2.2.1</mavenVersion>
-    <cassandraVersion>2.1.7</cassandraVersion>
+    <cassandraVersion>3.5</cassandraVersion>
     <slf4jVersion>1.7.2</slf4jVersion>
     <log4jVersion>2.1</log4jVersion>
     <commonsLoggingVersion>1.1.1</commonsLoggingVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ under the License.
   <properties>
     <mavenVersion>2.2.1</mavenVersion>
     <cassandraVersion>3.5</cassandraVersion>
-    <slf4jVersion>1.7.2</slf4jVersion>
+    <slf4jVersion>1.7.7</slf4jVersion>
     <log4jVersion>2.1</log4jVersion>
     <commonsLoggingVersion>1.1.1</commonsLoggingVersion>
     <cleanPluginVersion>2.5</cleanPluginVersion>
@@ -139,25 +139,6 @@ under the License.
           <artifactId>logback-classic</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.xerial.snappy</groupId>
-      <artifactId>snappy-java</artifactId>
-      <version>1.0.5</version>
-    </dependency>
-    <!-- Cassandra have not been tracking their transitive dependencies correctly -->
-    <dependency>
-      <artifactId>netty</artifactId>
-      <groupId>org.jboss.netty</groupId>
-      <version>3.2.9.Final</version> <!-- 3.5.9.Final is not available in central -->
-    </dependency>
-    <!-- end of transitive dependency fix-up -->
-    <!-- this is instead of commons-logging -->
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>jcl-over-slf4j</artifactId>
-      <version>${slf4jVersion}</version>
-      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
@@ -380,7 +361,7 @@ under the License.
         <artifactId>slf4j-api</artifactId>
         <version>${slf4jVersion}</version>
       </dependency>
-    </dependencies> 
+    </dependencies>
   </dependencyManagement>
 
   <reporting>

--- a/src/it/smoke/pom.xml
+++ b/src/it/smoke/pom.xml
@@ -149,6 +149,7 @@ under the License.
         <configuration>
           <loadAfterFirstStart>false</loadAfterFirstStart>
           <cuLoadAfterFirstStart>false</cuLoadAfterFirstStart>
+          <startNativeTransport>true</startNativeTransport>
           <rpcPort>${cassandraPort}</rpcPort>
           <storagePort>${cassandra.storagePort}</storagePort>
           <stopPort>${cassandra.stopPort}</stopPort>

--- a/src/it/smoke/src/cassandra/cql/load.cql
+++ b/src/it/smoke/src/cassandra/cql/load.cql
@@ -1,6 +1,4 @@
-create keyspace TestKeyspace
-    with strategy_class = 'SimpleStrategy'
-    and strategy_options:replication_factor = 1;
+create keyspace TestKeyspace with replication = {'class':'SimpleStrategy', 'replication_factor':1};
 
 use TestKeyspace;
-create columnfamily Test (key uuid PRIMARY KEY) with comparator='UTF8Type';
+create table Test (key uuid PRIMARY KEY);

--- a/src/it/smoke/src/test/java/smoke/SmokeIT.java
+++ b/src/it/smoke/src/test/java/smoke/SmokeIT.java
@@ -43,7 +43,7 @@ public class SmokeIT
         tr.open();
         try
         {
-            assertThat(client.describe_keyspace("TestKeyspace").getStrategy_options().entrySet(),
+            assertThat(client.describe_keyspace("testkeyspace").getStrategy_options().entrySet(),
                     hasItem((Map.Entry<String, String>)new AbstractMap.SimpleEntry<String,String>("replication_factor","1")));
         } finally
         {

--- a/src/it/spaces in path/pom.xml
+++ b/src/it/spaces in path/pom.xml
@@ -135,6 +135,7 @@ under the License.
         </executions>
         <configuration>
           <loadAfterFirstStart>false</loadAfterFirstStart>
+          <startNativeTransport>true</startNativeTransport>
           <rpcPort>${cassandraPort}</rpcPort>
           <storagePort>${cassandra.storagePort}</storagePort>
           <stopPort>${cassandra.stopPort}</stopPort>

--- a/src/it/spaces in path/src/cassandra/cql/load.cql
+++ b/src/it/spaces in path/src/cassandra/cql/load.cql
@@ -1,6 +1,4 @@
-create keyspace TestKeyspaceWithSpace
-    with strategy_class = 'SimpleStrategy'
-    and strategy_options:replication_factor = 1;
+create keyspace TestKeyspaceWithSpace with replication = {'class':'SimpleStrategy', 'replication_factor':1};
 
 use TestKeyspaceWithSpace;
-create columnfamily Test (key uuid PRIMARY KEY) with comparator='UTF8Type';
+create table Test (key uuid PRIMARY KEY);

--- a/src/it/spaces in path/src/test/java/smoke/SmokeIT.java
+++ b/src/it/spaces in path/src/test/java/smoke/SmokeIT.java
@@ -43,7 +43,7 @@ public class SmokeIT
         tr.open();
         try
         {
-            assertThat(client.describe_keyspace("TestKeyspaceWithSpace").getStrategy_options().entrySet(),
+            assertThat(client.describe_keyspace("testkeyspacewithspace").getStrategy_options().entrySet(),
                     hasItem((Map.Entry<String, String>)new AbstractMap.SimpleEntry<String,String>("replication_factor","1")));
         } finally
         {

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -38,6 +38,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -611,6 +612,10 @@ public abstract class AbstractCassandraMojo
         createCassandraHome( cassandraDir, listenAddress, rpcAddress, initialToken, seeds );
         CommandLine commandLine = newJavaCommandLine();
         commandLine.addArgument( "-Xmx" + maxMemory + "m" );
+        //Only value should be quoted so we have to do it ourselves explicitly and disable additional quotation of whole
+        //argument because it causes errors during launch. Also URLEncode.encode on value seems to work correctly too,
+        //it is done for log4j.configuration during toURL().toString() conversion.
+        commandLine.addArgument( "-Dcassandra.storagedir=" + org.apache.commons.exec.util.StringUtils.quoteArgument(cassandraDir.getAbsolutePath()), false);
         if ( stopKey != null && stopPort > 0 && stopPort < 65536 )
         {
             commandLine.addArgument( "-D" + CassandraMonitor.KEY_PROPERTY_NAME + "=" + stopKey );

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -30,7 +30,7 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
      * @parameter expression="${cql.version}"
      * @since 1.2.1-2
      */
-    private String cqlVersion = "2.0.0";
+    private String cqlVersion = "3.4.0";
 
     protected String readFile(File file) throws MojoExecutionException
     {

--- a/src/main/java/org/codehaus/mojo/cassandra/ThriftApiOperation.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/ThriftApiOperation.java
@@ -10,7 +10,7 @@ public abstract class ThriftApiOperation {
   private String keyspace;
   private final String rpcAddress;
   private final int rpcPort;
-  private String cqlVersion = "2.0.0";
+  private String cqlVersion = "3.4.0";
 
   public ThriftApiOperation(String rpcAddress, int rpcPort)
   {


### PR DESCRIPTION
Currently plugin uses cassandra version 2. I've needed plugin to run cassandra version closest to our production  (we are using 3.5). After a couple of small fixes plugin managed to start cassandra v3, so far no errors, but haven't written that many tests yet.

I'm not sure if this one should be pulled, because of backward compatibility problems. Seems at some point plugin has to start having both support for v2 and v3. Keeping two trunk branches, backporting fixes and releasing something like 2.2-1 and 3.5-1?