### PR TITLE
rename expression to property because of deprecation

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -77,7 +77,7 @@ public abstract class AbstractCassandraMojo
     /**
      * The directory containing generated classes.
      *
-     * @parameter expression="${project.build.outputDirectory}"
+     * @parameter property="project.build.outputDirectory"
      * @required
      */
     private File classesDirectory;
@@ -85,7 +85,7 @@ public abstract class AbstractCassandraMojo
     /**
      * The directory containing generated test classes.
      *
-     * @parameter expression="${project.build.testOutputDirectory}"
+     * @parameter property="project.build.testOutputDirectory"
      * @required
      */
     private File testClassesDirectory;
@@ -109,7 +109,7 @@ public abstract class AbstractCassandraMojo
     /**
      * Skip the execution.
      *
-     * @parameter expression="${cassandra.skip}" default-value="false"
+     * @parameter property="cassandra.skip" default-value="false"
      */
     protected boolean skip;
 
@@ -151,21 +151,21 @@ public abstract class AbstractCassandraMojo
     /**
      * Port to listen to for the RPC interface.
      *
-     * @parameter expression="${cassandra.rpcPort}" default-value="9160"
+     * @parameter property="cassandra.rpcPort" default-value="9160"
      */
     protected int rpcPort;
 
     /**
      * Port to listen to for the JMX interface.
      *
-     * @parameter expression="${cassandra.jmxPort}" default-value="7199"
+     * @parameter property="cassandra.jmxPort" default-value="7199"
      */
     protected int jmxPort;
 
     /**
      * Port on which the CQL native transport listens for clients.
      *
-     * @parameter expression="${cassandra.nativeTransportPort}" default-value="9042"
+     * @parameter property="cassandra.nativeTransportPort" default-value="9042"
      * 
      * @since 2.0.0-1
      */
@@ -175,7 +175,7 @@ public abstract class AbstractCassandraMojo
      * Enable or disable the native transport server. Currently, only the Thrift 
      * server is started by default because the native transport is considered beta.
      *
-     * @parameter expression="${cassandra.startNativeTransport}" default-value="false"
+     * @parameter property="cassandra.startNativeTransport" default-value="false"
      * 
      * @since 2.0.0-1
      */
@@ -201,35 +201,35 @@ public abstract class AbstractCassandraMojo
     /**
      * Port to listen to for the Storage interface.
      *
-     * @parameter expression="${cassandra.storagePort}" default-value="7000"
+     * @parameter property="cassandra.storagePort" default-value="7000"
      */
     protected int storagePort;
 
     /**
      * Port to listen to for receiving the stop command over
      *
-     * @parameter expression="${cassandra.stopPort}" default-value="8081"
+     * @parameter property="cassandra.stopPort" default-value="8081"
      */
     protected int stopPort;
 
     /**
      * Key to be provided when stopping cassandra
      *
-     * @parameter expression="${cassandra.stopKey}" default-value="cassandra-maven-plugin"
+     * @parameter property="cassandra.stopKey" default-value="cassandra-maven-plugin"
      */
     protected String stopKey;
 
     /**
      * Number of megabytes to limit the cassandra JVM to.
      *
-     * @parameter expression="${cassandra.maxMemory}" default-value="512"
+     * @parameter property="cassandra.maxMemory" default-value="512"
      */
     protected int maxMemory;
 
     /**
      * The keyspace against which individual operations will be executed
      *
-     * @parameter expression="${cassandra.keyspace}"
+     * @parameter property="cassandra.keyspace"
      */
     protected String keyspace;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -27,7 +27,7 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
     /**
      * Version of CQL to use
      *
-     * @parameter expression="${cql.version}"
+     * @parameter property="cql.version"
      * @since 1.2.1-2
      */
     private String cqlVersion = "3.4.0";

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlLoadMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlLoadMojo.java
@@ -21,7 +21,7 @@ public abstract class AbstractCqlLoadMojo extends AbstractCqlExecMojo
     /**
      * Whether to ignore errors when loading the script.
      *
-     * @parameter expression="${cassandra.load.failure.ignore}"
+     * @parameter property="cassandra.load.failure.ignore"
      */
     private boolean loadFailureIgnore;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
@@ -26,32 +26,32 @@ public class CqlExecCassandraMojo extends AbstractCqlExecMojo {
   /**
    * The CQL script which will be executed
    *
-   * @parameter expression="${cassandra.cql.script}" default-value="${basedir}/src/cassandra/cql/exec.cql"
+   * @parameter property="cassandra.cql.script" default-value="${basedir}/src/cassandra/cql/exec.cql"
    */
   protected File cqlScript;
 
   /**
    * The CQL statement to execute singularly
    *
-   * @parameter expression="${cql.statement}"
+   * @parameter property="cql.statement"
    */
   protected String cqlStatement;
 
   /**
    * Expected type of the column value
-   * @parameter expression="${cql.defaultValidator}"
+   * @parameter property="cql.defaultValidator"
    */
   protected String defaultValidator = "BytesType";
 
   /**
    * Expected type of the key
-   * @parameter expression="${cql.keyValidator}"
+   * @parameter property="cql.keyValidator"
    */
   protected String keyValidator = "BytesType";
 
   /**
    * Expected type of the column name
-   * @parameter expression="${cql.comparator}"
+   * @parameter property="cql.comparator"
    */
   protected String comparator = "BytesType";
 

--- a/src/main/java/org/codehaus/mojo/cassandra/DeleteCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/DeleteCassandraMojo.java
@@ -46,14 +46,14 @@ public class DeleteCassandraMojo extends AbstractMojo
     /**
      * Skip the execution.
      *
-     * @parameter expression="${cassandra.skip}" default-value="false"
+     * @parameter property="cassandra.skip" default-value="false"
      */
     private boolean skip;
 
     /**
      * Fail execution in case of error.
      *
-     * @parameter expression="${cassandra.failOnError}" default-value="true"
+     * @parameter property="cassandra.failOnError" default-value="true"
      * @since 2.0.0-1
      */
     protected boolean failOnError;

--- a/src/main/java/org/codehaus/mojo/cassandra/DropColumnFamiliesMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/DropColumnFamiliesMojo.java
@@ -19,7 +19,7 @@ public class DropColumnFamiliesMojo extends AbstractSchemaCassandraMojo {
     /**
      * The one or more comma-delimited ColumnFamilies against to be dropped. 
      * If not specified, the Keyspace will be dropped.
-     * @parameter expression="${cassandra.columnFamilies}"
+     * @parameter property="cassandra.columnFamilies"
      */
     protected String columnFamilies;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/LoadCassandraUnitDataSetMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/LoadCassandraUnitDataSetMojo.java
@@ -48,7 +48,7 @@ public class LoadCassandraUnitDataSetMojo
     /**
      * Whether to ignore errors when loading the dataSet.
      *
-     * @parameter expression="${cassandra.cuload.failure.ignore}"
+     * @parameter property="cassandra.cuload.failure.ignore"
      */
     private boolean cuLoadFailureIgnore;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/RunCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/RunCassandraMojo.java
@@ -41,7 +41,7 @@ public class RunCassandraMojo
     /**
      * When {@code true}, if this is a clean start then the load script will be applied automatically.
      *
-     * @parameter expression="${cassandra.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.load.after.first.start" default-value="true"
      */
     private boolean loadAfterFirstStart;
 
@@ -56,7 +56,7 @@ public class RunCassandraMojo
     /**
      * Whether to ignore errors when loading the script.
      *
-     * @parameter expression="${cassandra.cu.load.failure.ignore}"
+     * @parameter property="cassandra.cu.load.failure.ignore"
      * @since 1.2.1-2
      */
     private boolean cuLoadFailureIgnore;
@@ -64,7 +64,7 @@ public class RunCassandraMojo
     /**
      * When {@code true}, if this is a clean start then the CassandraUnit dataSet will be applied automatically.
      *
-     * @parameter expression="${cassandra.cu.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.cu.load.after.first.start" default-value="true"
      * @since 1.2.1-2
      */
     private boolean cuLoadAfterFirstStart;

--- a/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
@@ -51,7 +51,7 @@ public class StartCassandraClusterMojo
     /**
      * When {@code true}, if this is a clean start then the load script will be applied automatically.
      *
-     * @parameter expression="${cassandra.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.load.after.first.start" default-value="true"
      */
     private boolean loadAfterFirstStart;
 
@@ -66,7 +66,7 @@ public class StartCassandraClusterMojo
     /**
      * Whether to ignore errors when loading the script.
      *
-     * @parameter expression="${cassandra.cu.load.failure.ignore}"
+     * @parameter property="cassandra.cu.load.failure.ignore"
      * @since 1.2.1-2
      */
     private boolean cuLoadFailureIgnore;
@@ -74,7 +74,7 @@ public class StartCassandraClusterMojo
     /**
      * When {@code true}, if this is a clean start then the CassandraUnit dataSet will be applied automatically.
      *
-     * @parameter expression="${cassandra.cu.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.cu.load.after.first.start" default-value="true"
      * @since 1.2.1-2
      */
     private boolean cuLoadAfterFirstStart;
@@ -82,7 +82,7 @@ public class StartCassandraClusterMojo
     /**
      * The number of nodes in the cluster.
      *
-     * @parameter expression="${cassandra.cluster.size}" default-value="4"
+     * @parameter property="cassandra.cluster.size" default-value="4"
      */
     private int clusterSize;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/StartCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StartCassandraMojo.java
@@ -49,7 +49,7 @@ public class StartCassandraMojo
     /**
      * When {@code true}, if this is a clean start then the load script will be applied automatically.
      *
-     * @parameter expression="${cassandra.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.load.after.first.start" default-value="true"
      */
     private boolean loadAfterFirstStart;
 
@@ -64,7 +64,7 @@ public class StartCassandraMojo
     /**
      * Whether to ignore errors when loading the script.
      *
-     * @parameter expression="${cassandra.cu.load.failure.ignore}"
+     * @parameter property="cassandra.cu.load.failure.ignore"
      * @since 1.2.1-2
      */
     private boolean cuLoadFailureIgnore;
@@ -72,7 +72,7 @@ public class StartCassandraMojo
     /**
      * When {@code true}, if this is a clean start then the CassandraUnit dataSet will be applied automatically.
      *
-     * @parameter expression="${cassandra.cu.load.after.first.start}" default-value="true"
+     * @parameter property="cassandra.cu.load.after.first.start" default-value="true"
      * @since 1.2.1-2
      */
     private boolean cuLoadAfterFirstStart;

--- a/src/main/java/org/codehaus/mojo/cassandra/StopCassandraClusterMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StopCassandraClusterMojo.java
@@ -38,14 +38,14 @@ public class StopCassandraClusterMojo extends AbstractMojo
     /**
      * Skip the execution.
      *
-     * @parameter expression="${cassandra.skip}" default-value="false"
+     * @parameter property="cassandra.skip" default-value="false"
      */
     private boolean skip;
 
     /**
      * Port to send stop command over
      *
-     * @parameter expression="${cassandra.stopPort}" default-value="8081"
+     * @parameter property="cassandra.stopPort" default-value="8081"
      * @required
      */
     protected int stopPort;
@@ -53,7 +53,7 @@ public class StopCassandraClusterMojo extends AbstractMojo
     /**
      * Key to provide when stopping cassandra
      *
-     * @parameter expression="${cassandra.stopKey}" default-value="cassandra-maven-plugin"
+     * @parameter property="cassandra.stopKey" default-value="cassandra-maven-plugin"
      * @required
      */
     protected String stopKey;
@@ -68,14 +68,14 @@ public class StopCassandraClusterMojo extends AbstractMojo
     /**
      * Port to listen to for the RPC interface.
      *
-     * @parameter expression="${cassandra.rpcPort}" default-value="9160"
+     * @parameter property="cassandra.rpcPort" default-value="9160"
      */
     protected int rpcPort;
 
     /**
      * The number of nodes in the cluster.
      *
-     * @parameter expression="${cassandra.cluster.size}" default-value="4"
+     * @parameter property="cassandra.cluster.size" default-value="4"
      */
     private int clusterSize;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/StopCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StopCassandraMojo.java
@@ -35,14 +35,14 @@ public class StopCassandraMojo extends AbstractMojo
     /**
      * Skip the execution.
      *
-     * @parameter expression="${cassandra.skip}" default-value="false"
+     * @parameter property="cassandra.skip" default-value="false"
      */
     private boolean skip;
 
     /**
      * Port to send stop command over
      *
-     * @parameter expression="${cassandra.stopPort}" default-value="8081"
+     * @parameter property="cassandra.stopPort" default-value="8081"
      * @required
      */
     protected int stopPort;
@@ -50,7 +50,7 @@ public class StopCassandraMojo extends AbstractMojo
     /**
      * Key to provide when stopping cassandra
      *
-     * @parameter expression="${cassandra.stopKey}" default-value="cassandra-maven-plugin"
+     * @parameter property="cassandra.stopKey" default-value="cassandra-maven-plugin"
      * @required
      */
     protected String stopKey;
@@ -65,7 +65,7 @@ public class StopCassandraMojo extends AbstractMojo
     /**
      * Port to listen to for the RPC interface.
      *
-     * @parameter expression="${cassandra.rpcPort}" default-value="9160"
+     * @parameter property="cassandra.rpcPort" default-value="9160"
      */
     protected int rpcPort;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/TruncateCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/TruncateCassandraMojo.java
@@ -21,13 +21,13 @@ public class TruncateCassandraMojo extends AbstractCassandraMojo
 {
 
     /**
-     * @parameter expression="${cassandra.keyspace}"
+     * @parameter property="cassandra.keyspace"
      * @required 
      */
     protected String keyspace;
     
     /**
-     * @parameter expression="${cassandra.columnFamily}"
+     * @parameter property="cassandra.columnFamily"
      * @required 
      */
     protected String columnFamily;


### PR DESCRIPTION
Avoid a lot of messages (312) like:

```
[WARNING] org.codehaus.mojo.cassandra.CleanupCassandraMojo#classesDirectory:
[WARNING]   The syntax
[WARNING]     @parameter expression="${property}"
[WARNING]   is deprecated, please use
[WARNING]     @parameter property="property"
[WARNING]   instead.
```

during build.