### PR TITLE
Log results based on ResultType to avoid NullPointerException

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
@@ -96,19 +96,28 @@ public class CqlExecCassandraMojo extends AbstractCqlExecMojo {
       getLog().info("-----------------------------------------------");
       for (CqlResult result : results)
       {
-          for (CqlRow row : result.getRows())
-          {
-              getLog().info("Row key: "+keyValidatorVal.getString(row.key));
-              getLog().info("-----------------------------------------------");
-              for (Column column : row.getColumns() )
-              {
-                  getLog().info(" name: "+comparatorVal.getString(column.name));
-                  getLog().info(" value: "+defaultValidatorVal.getString(column.value));
-                  getLog().info("-----------------------------------------------");
-              }
-
+          switch (result.type) {
+              case VOID:
+                  // Void method so nothing to log
+              case INT:
+                  getLog().info("Number result: " + result.getNum());
+              case ROWS:
+                  printRows(result);
           }
       }
   }
+
+    private void printRows(CqlResult result) {
+        for (CqlRow row : result.getRows()) {
+            getLog().info("Row key: " + keyValidatorVal.getString(row.key));
+            getLog().info("-----------------------------------------------");
+            for (Column column : row.getColumns()) {
+                getLog().info(" name: " + comparatorVal.getString(column.name));
+                getLog().info(" value: " + defaultValidatorVal.getString(column.value));
+                getLog().info("-----------------------------------------------");
+            }
+
+        }
+    }
 
 }


### PR DESCRIPTION
Please look at this merge request. We are using the cql-exec goal in out project and are having trouble with the NullPointerException in printResults.

I am on cassandra-maven-plugin version 2.1.7-1 (2.0.0-1 worked but we want to create tables with tuple<text,text> requiring 2.1 or higher).