### PR TITLE
Fix print results not breaking in the switch on result.type

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/CqlExecCassandraMojo.java
@@ -99,10 +99,13 @@ public class CqlExecCassandraMojo extends AbstractCqlExecMojo {
           switch (result.type) {
               case VOID:
                   // Void method so nothing to log
+                  break;
               case INT:
                   getLog().info("Number result: " + result.getNum());
+                  break;
               case ROWS:
                   printRows(result);
+                  break;
           }
       }
   }


### PR DESCRIPTION
The PR: https://github.com/mojohaus/cassandra-maven-plugin/pull/20 did not fix the NPE completely because it does not break the switch after the two first statements