### PR TITLE
statement.split(";") cannot be used with strings which contains symbo…

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -53,7 +53,7 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
      * It is not enabled by default since has not been extensively tested.
      *
      * @parameter default-value=false
-     * @since 3.6
+     * @since 3.7
      */
     protected boolean useCqlLexer = false;
 

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -95,7 +95,7 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
         private CqlExecOperation(String statements)
         {
             super(rpcAddress, rpcPort);
-            this.statements = statements.split(";");
+            this.statements = statements.split("(?m);\\s*$");
             if (StringUtils.isNotBlank(keyspace))
             {
                 getLog().info("setting keyspace: " + keyspace);

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -147,7 +147,6 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
         {
             super(rpcAddress, rpcPort);
             if (useCqlLexer) {
-                getLog().warn("********************************************************************************");
                 getLog().warn("Using CqlLexer has not been extensively tested");
                 this.statements = splitStatementsUsingCqlLexer(statements);
             } else {

--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojo.java
@@ -10,6 +10,10 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.antlr.runtime.ANTLRStringStream;
+import org.antlr.runtime.CommonToken;
+import org.antlr.runtime.Token;
+import org.apache.cassandra.cql3.CqlLexer;
 import org.apache.cassandra.thrift.Cassandra.Client;
 import org.apache.cassandra.thrift.Compression;
 import org.apache.cassandra.thrift.ConsistencyLevel;
@@ -41,6 +45,17 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
      * @since 3.6
      */
     protected String cqlEncoding = Charset.defaultCharset().name();
+
+    /**
+     * Should we use the CqlLexer when loading the cql file. This should be better than than the default behaviour
+     * which is to just split input on ; since it handles ; in comments and strings.
+     *
+     * It is not enabled by default since has not been extensively tested.
+     *
+     * @parameter default-value=false
+     * @since 3.6
+     */
+    protected boolean useCqlLexer = false;
 
     protected String readFile(File file) throws MojoExecutionException
     {
@@ -87,6 +102,42 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
         return results;
     }
 
+    /**
+     * Best effort to somewhat parse the cql input instead of just splitting on ; which
+     * breaks badly if you have ; in strings or comments.
+     * Parsing is done using the CqlLexer class
+     */
+    protected static String[] splitStatementsUsingCqlLexer(String statements) {
+        ANTLRStringStream stream = new ANTLRStringStream(statements);
+        CqlLexer lexer = new CqlLexer(stream);
+        ArrayList<String> statementList = new ArrayList<String>();
+        StringBuffer currentStatement = new StringBuffer();
+        // Not the prettiest code i ever wrote, but it gets the job done.
+        for (Token token = lexer.nextToken(); token.getType() != Token.EOF; token = lexer.nextToken()) {
+            if (token.getText().equals(";")) {
+                // when we meet a ; terminate current statement and prepare the next
+                currentStatement.append(";");
+                statementList.add(currentStatement.toString());
+                currentStatement = new StringBuffer();
+            } else if (token.getType() == CqlLexer.STRING_LITERAL) {
+                // If we meet a string we should quote it and escape any enclosed ' as ''
+                currentStatement.append("'");
+                // TODO: There must be a cassandra util method somewhere that escapes a string for sql
+                currentStatement.append(token.getText().replaceAll("'", "''"));
+                currentStatement.append("'");
+            } else if (token.getType() == CqlLexer.COMMENT) {
+                // skip
+            } else {
+                currentStatement.append(token.getText());
+            }
+        }
+        if (currentStatement.length() > 0 && currentStatement.toString().trim().length() > 0) {
+            statementList.add(currentStatement.toString());
+        }
+        return statementList.toArray(new String[statementList.size()]);
+    }
+
+
     private class CqlExecOperation extends ThriftApiOperation
     {
         private final List<CqlResult> results = new ArrayList<CqlResult>();
@@ -95,7 +146,13 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
         private CqlExecOperation(String statements)
         {
             super(rpcAddress, rpcPort);
-            this.statements = statements.split("(?m);\\s*$");
+            if (useCqlLexer) {
+                getLog().warn("********************************************************************************");
+                getLog().warn("Using CqlLexer has not been extensively tested");
+                this.statements = splitStatementsUsingCqlLexer(statements);
+            } else {
+                this.statements = statements.split(";");
+            }
             if (StringUtils.isNotBlank(keyspace))
             {
                 getLog().info("setting keyspace: " + keyspace);
@@ -112,6 +169,9 @@ public abstract class AbstractCqlExecMojo extends AbstractCassandraMojo
             {
                 if (StringUtils.isNotBlank(statement))
                 {
+                    if (getLog().isDebugEnabled()) {
+                        getLog().debug("Executing cql statement: " + statement);
+                    }
                     results.add(executeStatement(client, statement));
                 }
             }

--- a/src/test/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/cassandra/AbstractCqlExecMojoTest.java
@@ -1,0 +1,32 @@
+package org.codehaus.mojo.cassandra;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class AbstractCqlExecMojoTest {
+
+    @Test
+    public void splitStatementsUsingCqlLexerWithSemicolonTest() {
+        splitStatementsUsingCqlLexerTest("SELECT * FROM tbl1 WHERE col1 = 'abc1;def1';SELECT * FROM tbl2 WHERE col2 = 'abc2;def2';", "SELECT * FROM tbl1 WHERE col1 = 'abc1;def1';", "SELECT * FROM tbl2 WHERE col2 = 'abc2;def2';");
+    }
+
+    @Test
+    public void splitStatementsUsingCqlLexerWithCommentTest() {
+        splitStatementsUsingCqlLexerTest("--\nSELECT * FROM tbl1 WHERE col1 = '--';", "SELECT * FROM tbl1 WHERE col1 = '--';");
+    }
+
+    @Test
+    public void splitStatementsUsingCqlLexerWithEmptyInput() {
+        splitStatementsUsingCqlLexerTest("");
+        splitStatementsUsingCqlLexerTest(";;;", ";", ";", ";");
+    }
+
+    public void splitStatementsUsingCqlLexerTest(String input, String...expected) {
+        String[] split = AbstractCqlExecMojo.splitStatementsUsingCqlLexer(input);
+        assertEquals("Split does not match expected number of statements", expected.length, split.length);
+        for (int i = 0; i < expected.length; i++) {
+            assertEquals(expected[i], split[i]);
+        }
+    }
+}


### PR DESCRIPTION
…l ";" like "vasya;petya". I think, it would be better to check for the end of line after ";" symbol. At least we would have an opportunity to use semicolons in text.

Example for test:
https://github.com/urvanov-ru/cassandra-maven-plugin-semicolon-test
