### PR TITLE
Example added to allow running integration test Cassandra Server 3.x.

### DIFF
--- a/src/site/apt/examples/integration-tests.apt.vm
+++ b/src/site/apt/examples/integration-tests.apt.vm
@@ -178,6 +178,66 @@ ifconfig lo0 alias 127.0.0.2
   {{{http://mojo.codehaus.org/build-helper-maven-plugin/reserve-network-port-mojo.html}build-helper:reserve-network-port}}
   to allocate ports.
 
+* Multi JVM use
+
+ To use JDK8 with Cassandra Server 3.x in combination with Failsafe integration tests you need to use Toolchains.
+ First we need to configure some Toolchains with Maven. Making the more recent the default for your project. See the
+ {{{https://maven.apache.org/guides/mini/guide-using-toolchains.html}Toolchains Plugin}} for instructions.
+
+ Additionally add another execution to Toolchains. To set JDK8 during the maven-failsafe-plugin pre-integration-test phase
+
+---
+<plugin>
+ <groupId>org.apache.maven.plugins</groupId>
+ <artifactId>maven-toolchains-plugin</artifactId>
+ <version>3.0.0</version>
+ <executions>
+   <execution>
+     <id>default-pre-integration-test</id>
+     <phase>pre-integration-test</phase>
+     <goals>
+       <goal>toolchain</goal>
+     </goals>
+     <configuration>
+       <toolchains>
+         <jdk>
+           <version>1.8</version>
+           <vendor>OpenJDK</vendor>
+         </jdk>
+       </toolchains>
+     </configuration>
+   </execution>
+ </executions>
+</plugin>
+---
+
+ Finally override the toolchain assigned during pre-integration-test phase. So that the integration-test phase executes with
+ the intended more recent JDK.
+
+---
+<plugin>
+ <artifactId>maven-failsafe-plugin</artifactId>
+ <configuration>
+   <jvm>/usr/lib/jvm/java-11-openjdk/bin/java</jvm>
+ </configuration>
+</plugin>
+---
+
+ This will result in the following during the lifecycle
+
+*-----------------------+---------------------------------+---------+
+| <<Phase>>             | <<Goal(s)>>                     | <<JDK>> |
+*-----------------------+---------------------------------+---------+
+| pre-integration-test  | cassandra:start                 | 8       |
+*-----------------------+---------------------------------+---------+
+| integration-test      | failsafe:integration-test       | 11      |
+*-----------------------+---------------------------------+---------+
+| post-integration-test | cassandra:stop                  | 8       |
+*-----------------------+---------------------------------+---------+
+| verify                | failsafe:verify                 | 11      |
+*-----------------------+---------------------------------+---------+
+
+
 * Trademarks
 
   Apache, Apache Maven, Apache Cassandra, Maven, Cassandra and the Apache feather logo are trademarks of The Apache Software Foundation.


### PR DESCRIPTION
 This PR is intended to solve the issue raised in #39  by adding some more documentation.
 There is some use cases that will require testing with v3.x Cassandra Server. For projects that have moved on from JDK8.