### PR TITLE
Adding jdk11 options

### DIFF
--- a/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/AbstractCassandraMojo.java
@@ -262,6 +262,11 @@ public abstract class AbstractCassandraMojo
         createCassandraJar( jarFile, mainClass, cassandraDir );
     }
 
+
+    protected boolean useJdk11Options() {
+        return false;
+    }
+
     /**
      * Create a jar with just a manifest containing a Main-Class entry for SurefireBooter and a Class-Path entry for
      * all classpath elements. Copied from surefire (ForkConfiguration#createJar())
@@ -612,6 +617,33 @@ public abstract class AbstractCassandraMojo
         createCassandraHome( cassandraDir, listenAddress, rpcAddress, initialToken, seeds );
         CommandLine commandLine = newJavaCommandLine();
         commandLine.addArgument( "-Xmx" + maxMemory + "m" );
+
+        if (useJdk11Options())
+        {
+            commandLine.addArgument( "-Djdk.attach.allowAttachSelf=true" );
+            commandLine.addArgument( "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.base/jdk.internal.ref=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.management.rmi/com.sun.jmx.remote.internal.rmi=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.rmi/sun.rmi.registry=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.rmi/sun.rmi.server=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-exports=java.sql/java.sql=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.lang.module=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.math=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.module=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/jdk.internal.util.jar=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.io=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.nio=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED" );
+            commandLine.addArgument( "--add-opens=java.base/java.util=ALL-UNNAMED" );
+        }
+
         //Only value should be quoted so we have to do it ourselves explicitly and disable additional quotation of whole
         //argument because it causes errors during launch. Also URLEncode.encode on value seems to work correctly too,
         //it is done for log4j.configuration during toURL().toString() conversion.

--- a/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StartCassandraClusterMojo.java
@@ -89,6 +89,21 @@ public class StartCassandraClusterMojo
     private int clusterSize;
 
     /**
+     * If <code>true</code>, the java options --add-exports and --add-opens will be added to the cassandra start. Which
+     * is needed, if cassandra runs with a Java runtime >= 11
+     *
+     * @parameter property="cassandra.addJdk11Options" default-value="false"
+     * @since 3.7
+     */
+    protected boolean addJdk11Options;
+
+    @Override
+    protected boolean useJdk11Options( )
+    {
+        return addJdk11Options;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public void execute()

--- a/src/main/java/org/codehaus/mojo/cassandra/StartCassandraMojo.java
+++ b/src/main/java/org/codehaus/mojo/cassandra/StartCassandraMojo.java
@@ -80,6 +80,21 @@ public class StartCassandraMojo
     private boolean cuLoadAfterFirstStart;
 
     /**
+     * If <code>true</code>, the java options --add-exports and --add-opens will be added to the cassandra start. Which
+     * is needed, if cassandra runs with a Java runtime >= 11
+     *
+     * @parameter property="cassandra.addJdk11Options" default-value="false"
+     * @since 3.7
+     */
+    protected boolean addJdk11Options;
+
+    @Override
+    protected boolean useJdk11Options( )
+    {
+        return addJdk11Options;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public void execute()


### PR DESCRIPTION
The Cassandra start in the current version (3.x) needs java options  (--add-export, --add-opens) to give cassandra access to certain java modules.
I added a boolean config parameter/property that activates these options.

It would be helpful to have this option, as our Apache Archiva project uses this plugin for integration tests and currently we cannot run our build on JDK 17.